### PR TITLE
updating Gopkg.toml with the new version of gopacket

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,10 +24,9 @@
 #   go-tests = true
 #   unused-packages = true
 
-
 [[constraint]]
   name = "github.com/google/gopacket"
-  revision = "8af772c0bcc826f671fd7c133917fec9686d720d"
+  revision = "1a2aa715ae412f434ae0bbb833442d14880cab8a"
 
 [[constraint]]
   name = "github.com/hashicorp/golang-lru"


### PR DESCRIPTION
**NOTE** : This PR will need to be accepted in lock-step with the related PR to the `albiondata-client` repo, since the client relies on this library, and both `gopacket` versions need to be the same. Once I've created the other PR, I'll link them to each other.

----

This PR will update the `google/gopacket` library to the newest version, which solves the inability to build the project with newer versions of Go. This has been briefly tested to ensure that the compiled client properly sends messages to the NATS network. This has only been tested on Windows, but I'd appreciate help with testing building in OSX and Linux.

For example without updating these libraries in both `photon_spectator` and `albiondata-client` you end up with a `go build` error message similar to this:

```
gradius@gameshell MINGW64 ~/go/src/github.com/broderickhyman/albiondata-client (master)
$ go build cmd/albiondata-client/albiondata-client.go
# github.com/broderickhyman/albiondata-client/vendor/github.com/google/gopacket/pcap
vendor\github.com\google\gopacket\pcap\pcap.go:182:7: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:409:13: identifier "_Ctype_struct_pcap_stat" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:454:49: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:477:10: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:510:41: identifier "_Ctype_struct_bpf_insn" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:582:66: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:595:19: identifier "_Ctype_struct_bpf_insn" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:705:34: identifier "_Ctype_struct_pcap_addr" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:708:56: identifier "_Ctype_struct_pcap_addr" may conflict with identifiers generated by cgo
```