### PR TITLE
Changing message parameter 120 from SliceInt8Type to SliceUInt8Type

### DIFF
--- a/decode_reliable_message.go
+++ b/decode_reliable_message.go
@@ -23,7 +23,7 @@ const (
 	OperationResponseType = 112
 	OperationRequestType  = 113
 	StringType            = 115
-	SliceInt8Type         = 120
+	SliceUInt8Type        = 120
 	SliceType             = 121
 	ObjectArrayType       = 122
 )
@@ -75,8 +75,8 @@ func decodeType(buf *bytes.Buffer, paramType uint8) interface{} {
 		} else {
 			return result
 		}
-	case SliceInt8Type:
-		result, err := decodeSliceInt8Type(buf)
+	case SliceUInt8Type:
+		result, err := decodeSliceUInt8Type(buf)
 		if err != nil {
 			return fmt.Sprintf("ERROR - Slice Int8 - %v", err.Error())
 		} else {
@@ -164,11 +164,11 @@ func decodeSlice(buf *bytes.Buffer) (interface{}, error) {
 		}
 
 		return array, nil
-	case SliceInt8Type:
-		array := make([][]int8, length)
+	case SliceUInt8Type:
+		array := make([][]uint8, length)
 
 		for j := 0; j < int(length); j++ {
-			result, err := decodeSliceInt8Type(buf)
+			result, err := decodeSliceUInt8Type(buf)
 			if err != nil {
 				return nil, err
 			}
@@ -258,6 +258,28 @@ func decodeSliceInt8Type(buf *bytes.Buffer) ([]int8, error) {
 
 	for j := 0; j < int(length); j++ {
 		var temp int8
+		err := binary.Read(buf, binary.BigEndian, &temp)
+		if err != nil {
+			return nil, err
+		}
+		array[j] = temp
+	}
+
+	return array, nil
+}
+
+func decodeSliceUInt8Type(buf *bytes.Buffer) ([]uint8, error) {
+	var length uint32
+
+	err := binary.Read(buf, binary.BigEndian, &length)
+	if err != nil {
+		return nil, err
+	}
+
+	array := make([]uint8, length)
+
+	for j := 0; j < int(length); j++ {
+		var temp uint8
 		err := binary.Read(buf, binary.BigEndian, &temp)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Parameter 120 was erroneously for int8s instead of unit8s

This bug was found while trying to add market history in the albiondata-client https://github.com/broderickhyman/albiondata-client/pull/36